### PR TITLE
Avoid trying to rewrite an INSERT...RETURNING

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 commit = True
 tag = True
 

--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,1 @@
+TEST_CONNECTION_STRING=postgresql://postgres:postgres@pg:5432/test_db

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           docker compose build tests-with-coverage --quiet
       - name: Run Tests via Docker
         run: |
-          docker compose --env-file .env.docker run tests-with-coverage
+          docker compose --env-file .env.docker run --quiet-pull tests-with-coverage
       - name: Show Test Logs if tests failed
         if: ${{ failure() }}
         run: docker compose logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ main, dev/* ]
+    branches: [ main, '*' ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -19,7 +19,7 @@ jobs:
           docker compose build tests-with-coverage --no-cache
       - name: Run Tests via Docker
         run: |
-          docker compose up --exit-code-from tests-with-coverage tests-with-coverage
+          docker compose --env-file .env.docker run tests-with-coverage
       - name: Show Test Logs if tests failed
         if: ${{ failure() }}
         run: docker compose logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,10 @@ jobs:
       - name: Build Docker image
         run: |
           docker compose build tests-with-coverage --quiet
+          docker compose pull
       - name: Run Tests via Docker
         run: |
-          docker compose --env-file .env.docker run --quiet-pull tests-with-coverage
+          docker compose --env-file .env.docker run tests-with-coverage
       - name: Show Test Logs if tests failed
         if: ${{ failure() }}
         run: docker compose logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build Docker image
         run: |
-          docker compose build tests-with-coverage --no-cache
+          docker compose build tests-with-coverage --quiet
       - name: Run Tests via Docker
         run: |
           docker compose --env-file .env.docker run tests-with-coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ RUN poetry install -E test
 
 FROM content as testing_and_coverage
 
-CMD poetry run pytest --cov=sqlalchemy_easy_softdelete --cov-branch --cov-report=term-missing --cov-report=xml tests
+CMD sleep 2 && poetry run pytest --cov=sqlalchemy_easy_softdelete --cov-branch --cov-report=term-missing --cov-report=xml tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
   # Test Runner
   ##############################
   tests:
+    depends_on:
+      - pg
+    env_file:
+      - .env.docker
     environment:
       - PYTHONUNBUFFERED=1
     build:
@@ -13,6 +17,28 @@ services:
   ##############################
   tests-with-coverage:
     extends: "tests"
+
     # Set up volume so that coverage information can be relayed back to the outside
     volumes:
       - "./:/library"
+
+  ##############################
+  # PostgreSQL Instance
+  ##############################
+  pg:
+    image: postgres:14
+    volumes:
+      - pg_db_data:/var/lib/postgresql/data
+    ports:
+      - "9991:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: test_db
+    logging:
+      options:
+        max-size: "1m"
+
+
+volumes:
+  pg_db_data:

--- a/makefile
+++ b/makefile
@@ -1,11 +1,7 @@
 sources = sqlalchemy_easy_softdelete
 
 .PHONY: test format lint unittest coverage pre-commit clean
-test: format lint unittest
-
-format:
-	isort $(sources) tests
-	black $(sources) tests
+test: lint unittest
 
 lint:
 	flake8 $(sources) tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -587,6 +587,14 @@ python-versions = ">=3.6.2"
 wcwidth = "*"
 
 [[package]]
+name = "psycopg2"
+version = "2.9.4"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "ptyprocess"
 version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
@@ -1059,7 +1067,7 @@ test = ["pytest", "black", "isort", "flake8", "flake8-docstrings", "pytest-cov"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "efb614c3ce5aceff4dd63bbf42b26ae11a482fac5fddb09f721c4f9be9a8ad4c"
+content-hash = "49fbf35ce105392b0133d8c930b4f6304024c0b9bfad7c4d2c4aea6574de5bff"
 
 [metadata.files]
 appnope = [
@@ -1442,6 +1450,19 @@ pre-commit = [
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.31-py3-none-any.whl", hash = "sha256:9696f386133df0fc8ca5af4895afe5d78f5fcfe5258111c2a79a1c3e41ffa96d"},
     {file = "prompt_toolkit-3.0.31.tar.gz", hash = "sha256:9ada952c9d1787f52ff6d5f3484d0b4df8952787c087edf6a1f7c2cb1ea88148"},
+]
+psycopg2 = [
+    {file = "psycopg2-2.9.4-cp310-cp310-win32.whl", hash = "sha256:8de6a9fc5f42fa52f559e65120dcd7502394692490c98fed1221acf0819d7797"},
+    {file = "psycopg2-2.9.4-cp310-cp310-win_amd64.whl", hash = "sha256:1da77c061bdaab450581458932ae5e469cc6e36e0d62f988376e9f513f11cb5c"},
+    {file = "psycopg2-2.9.4-cp36-cp36m-win32.whl", hash = "sha256:a11946bad3557ca254f17357d5a4ed63bdca45163e7a7d2bfb8e695df069cc3a"},
+    {file = "psycopg2-2.9.4-cp36-cp36m-win_amd64.whl", hash = "sha256:46361c054df612c3cc813fdb343733d56543fb93565cff0f8ace422e4da06acb"},
+    {file = "psycopg2-2.9.4-cp37-cp37m-win32.whl", hash = "sha256:aafa96f2da0071d6dd0cbb7633406d99f414b40ab0f918c9d9af7df928a1accb"},
+    {file = "psycopg2-2.9.4-cp37-cp37m-win_amd64.whl", hash = "sha256:aa184d551a767ad25df3b8d22a0a62ef2962e0e374c04f6cbd1204947f540d61"},
+    {file = "psycopg2-2.9.4-cp38-cp38-win32.whl", hash = "sha256:839f9ea8f6098e39966d97fcb8d08548fbc57c523a1e27a1f0609addf40f777c"},
+    {file = "psycopg2-2.9.4-cp38-cp38-win_amd64.whl", hash = "sha256:c7fa041b4acb913f6968fce10169105af5200f296028251d817ab37847c30184"},
+    {file = "psycopg2-2.9.4-cp39-cp39-win32.whl", hash = "sha256:07b90a24d5056687781ddaef0ea172fd951f2f7293f6ffdd03d4f5077801f426"},
+    {file = "psycopg2-2.9.4-cp39-cp39-win_amd64.whl", hash = "sha256:849bd868ae3369932127f0771c08d1109b254f08d48dc42493c3d1b87cb2d308"},
+    {file = "psycopg2-2.9.4.tar.gz", hash = "sha256:d529926254e093a1b669f692a3aa50069bc71faf5b0ecd91686a78f62767d52f"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "sqlalchemy-easy-softdelete"
-version = "0.5.0"
+version = "0.5.1"
 homepage = "https://github.com/flipbit03/sqlalchemy-easy-softdelete"
 description = "Easily add soft-deletion to your SQLAlchemy Models."
 authors = ["Cadu <cadu.coelho@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ bump2version = {version = "^1.0.1", optional = true}
 [tool.poetry.dev-dependencies]
 ipython = "^8.4.0"
 snapshottest = "^0.6.0"
+psycopg2 = "^2.9.4"
 
 [tool.poetry.extras]
 test = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ exclude = .git,
     .pytest_cache,
     .vscode,
     .github,
-    ./tests/snapshots/*
+    ./tests/*
     # By default test codes will be linted.
     # tests
 

--- a/sqlalchemy_easy_softdelete/__init__.py
+++ b/sqlalchemy_easy_softdelete/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Cadu"""
 __email__ = 'cadu.coelho@gmail.com'
-__version__ = '0.5.0'
+__version__ = '0.5.1'

--- a/sqlalchemy_easy_softdelete/handler/__init__.py
+++ b/sqlalchemy_easy_softdelete/handler/__init__.py
@@ -1,0 +1,1 @@
+"""Group of functions related to the query rewriting process."""

--- a/sqlalchemy_easy_softdelete/handler/sqlalchemy_easy_softdelete.py
+++ b/sqlalchemy_easy_softdelete/handler/sqlalchemy_easy_softdelete.py
@@ -1,3 +1,5 @@
+"""This module is responsible for activating the query rewriter."""
+
 from functools import cache
 
 from sqlalchemy.event import listens_for
@@ -8,6 +10,7 @@ from sqlalchemy_easy_softdelete.handler.rewriter import SoftDeleteQueryRewriter
 
 @cache
 def activate_soft_delete_hook(deleted_field_name: str, disable_soft_delete_option_name: str):
+    """Activate an event hook to rewrite the queries."""
     # Enable Soft Delete on all Relationship Loads which implement SoftDeleteMixin
     @listens_for(Session, "do_orm_execute")
     def soft_delete_execute(state: ORMExecuteState):

--- a/sqlalchemy_easy_softdelete/mixin.py
+++ b/sqlalchemy_easy_softdelete/mixin.py
@@ -1,3 +1,5 @@
+"""Functions related to dynamic generation of the soft-delete mixin."""
+
 from datetime import datetime
 from typing import Any, Callable, Optional, Type
 
@@ -18,6 +20,7 @@ def generate_soft_delete_mixin_class(
     generate_undelete_method: bool = True,
     undelete_method_name: str = "undelete",
 ) -> Type:
+    """Generate the actual soft-delete Mixin class."""
     class_attributes = {deleted_field_name: Column(deleted_field_name, deleted_field_type)}
 
     if generate_delete_method:

--- a/tests/model.py
+++ b/tests/model.py
@@ -13,7 +13,7 @@ class TestModelBase:
     def __tablename__(cls) -> str:
         return cls.__name__.lower()
 
-    id = Column(Integer, primary_key=True)
+    id = Column(Integer, primary_key=True, autoincrement=True)
 
     def __repr__(self):
         return f"<{self.__class__.__name__} id={self.id}>"
@@ -22,6 +22,14 @@ class TestModelBase:
 class SoftDeleteMixin(generate_soft_delete_mixin_class()):
     # for autocomplete
     deleted_at: datetime
+
+
+class SDSimpleTable(TestModelBase, SoftDeleteMixin):
+
+    int_field = Column(Integer)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} id={self.id} deleted={bool(self.deleted_at)}>"
 
 
 class SDParent(TestModelBase, SoftDeleteMixin):
@@ -47,6 +55,8 @@ class SDBaseRequest(
 ):
     request_type = Column(String(50))
 
+    base_field = Column(Integer)
+
     __mapper_args__ = {
         "polymorphic_identity": "sdbaserequest",
         "polymorphic_on": request_type,
@@ -56,7 +66,7 @@ class SDBaseRequest(
 class SDDerivedRequest(SDBaseRequest):
     id: Integer = Column(Integer, ForeignKey("sdbaserequest.id"), primary_key=True)
 
-    int_field = Column(Integer)
+    derived_field = Column(Integer)
 
     __mapper_args__ = {
         "polymorphic_identity": "sdderivedrequest",

--- a/tests/seed_data.py
+++ b/tests/seed_data.py
@@ -1,0 +1,46 @@
+import random
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from tests.model import SDChild, SDDerivedRequest, SDParent
+
+
+def generate_parent_child_object_hierarchy(
+    s: Session, parent_id: int, min_children: int = 1, max_children: int = 5, parent_deleted: bool = False
+):
+    # Fix a seed in the RNG for deterministic outputs
+    random.seed(parent_id)
+
+    # Generate the Parent
+    deleted_at = datetime.utcnow() if parent_deleted else None
+    new_parent = SDParent(id=parent_id, deleted_at=deleted_at)
+    s.add(new_parent)
+    s.flush()
+
+    active_children = random.randint(min_children, max_children)
+
+    # Add some active children
+    for active_id in range(active_children):
+        new_child = SDChild(id=parent_id * 1000 + active_id, parent=new_parent)
+        s.add(new_child)
+        s.flush()
+
+    # Add some soft-deleted children
+    for inactive_id in range(random.randint(min_children, max_children)):
+        new_soft_deleted_child = SDChild(
+            id=parent_id * 1000 + active_children + inactive_id,
+            parent=new_parent,
+            deleted_at=datetime.utcnow(),
+        )
+        s.add(new_soft_deleted_child)
+        s.flush()
+
+    s.commit()
+
+
+def generate_table_with_inheritance_obj(s: Session, obj_id: int, deleted: bool = False):
+    deleted_at = datetime.utcnow() if deleted else None
+    new_parent = SDDerivedRequest(id=obj_id, deleted_at=deleted_at)
+    s.add(new_parent)
+    s.commit()

--- a/tests/snapshots/snap_test_queries.py
+++ b/tests/snapshots/snap_test_queries.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import GenericRepr, Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['test_ensure_aggregate_from_multiple_table_deletion_works_active_object_count 1'] = '''SELECT count(*) AS count_1 
@@ -13,19 +12,19 @@ WHERE sdchild.deleted_at IS NULL AND sdparent.deleted_at IS NULL'''
 
 snapshots['test_ensure_aggregate_from_multiple_table_deletion_works_active_object_count 2'] = 1
 
-snapshots['test_ensure_table_with_inheritance_works 1'] = '''SELECT sdderivedrequest.id, sdbaserequest.id AS id_1, sdbaserequest.deleted_at, sdbaserequest.request_type, sdderivedrequest.int_field 
+snapshots['test_ensure_table_with_inheritance_works 1'] = '''SELECT sdderivedrequest.id, sdbaserequest.id AS id_1, sdbaserequest.deleted_at, sdbaserequest.request_type, sdbaserequest.base_field, sdderivedrequest.derived_field 
 FROM sdbaserequest JOIN sdderivedrequest ON sdbaserequest.id = sdderivedrequest.id 
 WHERE sdbaserequest.deleted_at IS NULL'''
 
 snapshots['test_ensure_table_with_inheritance_works 2'] = [
-    GenericRepr('<SDDerivedRequest id=0>'),
-    GenericRepr('<SDDerivedRequest id=1>')
+    GenericRepr('<SDDerivedRequest id=1000>'),
+    GenericRepr('<SDDerivedRequest id=1001>')
 ]
 
 snapshots['test_ensure_table_with_inheritance_works 3'] = [
-    GenericRepr('<SDDerivedRequest id=0>'),
-    GenericRepr('<SDDerivedRequest id=1>'),
-    GenericRepr('<SDDerivedRequest id=2>')
+    GenericRepr('<SDDerivedRequest id=1000>'),
+    GenericRepr('<SDDerivedRequest id=1001>'),
+    GenericRepr('<SDDerivedRequest id=1002>')
 ]
 
 snapshots['test_query_single_table 1'] = '''SELECT sdchild.id, sdchild.deleted_at, sdchild.parent_id 
@@ -33,10 +32,16 @@ FROM sdchild
 WHERE sdchild.deleted_at IS NULL'''
 
 snapshots['test_query_single_table 2'] = [
-    GenericRepr('<SDChild id=0 deleted=False       (parent_id=0)>'),
-    GenericRepr('<SDChild id=1 deleted=False       (parent_id=0)>'),
-    GenericRepr('<SDChild id=1000 deleted=False    (parent_id=1)>'),
-    GenericRepr('<SDChild id=2000 deleted=False    (parent_id=2)>')
+    GenericRepr('<SDChild id=1000000 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000001 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000002 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000003 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1001000 deleted=False (parent_id=1001)>'),
+    GenericRepr('<SDChild id=1002000 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002001 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002002 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002003 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002004 deleted=False (parent_id=1002)>')
 ]
 
 snapshots['test_query_union_sdchild 1'] = '''SELECT anon_1.sdchild_id, anon_1.sdchild_deleted_at, anon_1.sdchild_parent_id 
@@ -47,10 +52,16 @@ FROM sdchild
 WHERE sdchild.deleted_at IS NULL) AS anon_1'''
 
 snapshots['test_query_union_sdchild 2'] = [
-    GenericRepr('<SDChild id=0 deleted=False       (parent_id=0)>'),
-    GenericRepr('<SDChild id=1 deleted=False       (parent_id=0)>'),
-    GenericRepr('<SDChild id=1000 deleted=False    (parent_id=1)>'),
-    GenericRepr('<SDChild id=2000 deleted=False    (parent_id=2)>')
+    GenericRepr('<SDChild id=1000000 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000001 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000002 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000003 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1001000 deleted=False (parent_id=1001)>'),
+    GenericRepr('<SDChild id=1002000 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002001 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002002 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002003 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002004 deleted=False (parent_id=1002)>')
 ]
 
 snapshots['test_query_with_join 1'] = '''SELECT sdchild.id, sdchild.deleted_at, sdchild.parent_id 
@@ -58,9 +69,11 @@ FROM sdchild JOIN sdparent ON sdparent.id = sdchild.parent_id
 WHERE sdchild.deleted_at IS NULL AND sdparent.deleted_at IS NULL'''
 
 snapshots['test_query_with_join 2'] = [
-    GenericRepr('<SDChild id=0 deleted=False       (parent_id=0)>'),
-    GenericRepr('<SDChild id=1 deleted=False       (parent_id=0)>'),
-    GenericRepr('<SDChild id=1000 deleted=False    (parent_id=1)>')
+    GenericRepr('<SDChild id=1000000 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000001 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000002 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000003 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1001000 deleted=False (parent_id=1001)>')
 ]
 
 snapshots['test_query_with_table_clause_as_table 1'] = '''SELECT id 
@@ -76,14 +89,22 @@ WHERE sdchild.deleted_at IS NULL UNION SELECT sdchild.id AS sdchild_id, sdchild.
 FROM sdchild) AS anon_1'''
 
 snapshots['test_query_with_union_but_union_softdelete_disabled 2'] = [
-    GenericRepr('<SDChild id=0 deleted=False       (parent_id=0)>'),
-    GenericRepr('<SDChild id=1 deleted=False       (parent_id=0)>'),
-    GenericRepr('<SDChild id=2 deleted=True        (parent_id=0)>'),
-    GenericRepr('<SDChild id=3 deleted=True        (parent_id=0)>'),
-    GenericRepr('<SDChild id=1000 deleted=False    (parent_id=1)>'),
-    GenericRepr('<SDChild id=1001 deleted=True     (parent_id=1)>'),
-    GenericRepr('<SDChild id=1002 deleted=True     (parent_id=1)>'),
-    GenericRepr('<SDChild id=1003 deleted=True     (parent_id=1)>'),
-    GenericRepr('<SDChild id=2000 deleted=False    (parent_id=2)>'),
-    GenericRepr('<SDChild id=2001 deleted=True     (parent_id=2)>')
+    GenericRepr('<SDChild id=1000000 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000001 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000002 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000003 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000004 deleted=True (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1001000 deleted=False (parent_id=1001)>'),
+    GenericRepr('<SDChild id=1001001 deleted=True (parent_id=1001)>'),
+    GenericRepr('<SDChild id=1001002 deleted=True (parent_id=1001)>'),
+    GenericRepr('<SDChild id=1002000 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002001 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002002 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002003 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002004 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002005 deleted=True (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002006 deleted=True (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002007 deleted=True (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002008 deleted=True (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002009 deleted=True (parent_id=1002)>')
 ]

--- a/tests/snapshots/snap_test_seed_data.py
+++ b/tests/snapshots/snap_test_seed_data.py
@@ -4,24 +4,31 @@ from __future__ import unicode_literals
 
 from snapshottest import GenericRepr, Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['test_ensure_stable_seed_data 1'] = [
-    GenericRepr('<SDParent id=0 deleted=False>'),
-    GenericRepr('<SDParent id=1 deleted=False>'),
-    GenericRepr('<SDParent id=2 deleted=True>')
+    GenericRepr('<SDParent id=1000 deleted=False>'),
+    GenericRepr('<SDParent id=1001 deleted=False>'),
+    GenericRepr('<SDParent id=1002 deleted=True>')
 ]
 
 snapshots['test_ensure_stable_seed_data 2'] = [
-    GenericRepr('<SDChild id=0 deleted=False       (parent_id=0)>'),
-    GenericRepr('<SDChild id=1 deleted=False       (parent_id=0)>'),
-    GenericRepr('<SDChild id=2 deleted=True        (parent_id=0)>'),
-    GenericRepr('<SDChild id=3 deleted=True        (parent_id=0)>'),
-    GenericRepr('<SDChild id=1000 deleted=False    (parent_id=1)>'),
-    GenericRepr('<SDChild id=1001 deleted=True     (parent_id=1)>'),
-    GenericRepr('<SDChild id=1002 deleted=True     (parent_id=1)>'),
-    GenericRepr('<SDChild id=1003 deleted=True     (parent_id=1)>'),
-    GenericRepr('<SDChild id=2000 deleted=False    (parent_id=2)>'),
-    GenericRepr('<SDChild id=2001 deleted=True     (parent_id=2)>')
+    GenericRepr('<SDChild id=1000000 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000001 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000002 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000003 deleted=False (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1000004 deleted=True (parent_id=1000)>'),
+    GenericRepr('<SDChild id=1001000 deleted=False (parent_id=1001)>'),
+    GenericRepr('<SDChild id=1001001 deleted=True (parent_id=1001)>'),
+    GenericRepr('<SDChild id=1001002 deleted=True (parent_id=1001)>'),
+    GenericRepr('<SDChild id=1002000 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002001 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002002 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002003 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002004 deleted=False (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002005 deleted=True (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002006 deleted=True (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002007 deleted=True (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002008 deleted=True (parent_id=1002)>'),
+    GenericRepr('<SDChild id=1002009 deleted=True (parent_id=1002)>')
 ]

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,11 +1,12 @@
 """Tests for `sqlalchemy_easy_softdelete` package."""
 from typing import List
 
-from sqlalchemy import func, select, table, text
+import pytest
+from sqlalchemy import func, insert, select, table, text
 from sqlalchemy.orm import Query
 from sqlalchemy.sql import Select
 
-from tests.model import SDBaseRequest, SDChild, SDDerivedRequest, SDParent
+from tests.model import SDBaseRequest, SDChild, SDDerivedRequest, SDParent, SDSimpleTable
 
 
 def test_query_single_table(snapshot, seeded_session, rewriter):
@@ -13,7 +14,7 @@ def test_query_single_table(snapshot, seeded_session, rewriter):
     test_query: Query = seeded_session.query(SDChild)
 
     snapshot.assert_match(str(rewriter.rewrite_select(test_query.statement)))
-    snapshot.assert_match(test_query.all())
+    snapshot.assert_match(sorted(test_query.all(), key=lambda i: i.id))
 
 
 def test_query_with_join(snapshot, seeded_session, rewriter):
@@ -22,7 +23,7 @@ def test_query_with_join(snapshot, seeded_session, rewriter):
 
     snapshot.assert_match(str(rewriter.rewrite_select(test_query.statement)))
 
-    snapshot.assert_match(test_query.all())
+    snapshot.assert_match(sorted(test_query.all(), key=lambda i: i.id))
 
 
 def test_query_union_sdchild(snapshot, seeded_session, rewriter):
@@ -31,7 +32,7 @@ def test_query_union_sdchild(snapshot, seeded_session, rewriter):
 
     snapshot.assert_match(str(rewriter.rewrite_select(test_query.statement)))
 
-    snapshot.assert_match(test_query.all())
+    snapshot.assert_match(sorted(test_query.all(), key=lambda i: i.id))
 
 
 def test_query_with_union_but_union_softdelete_disabled(snapshot, seeded_session, rewriter):
@@ -52,7 +53,7 @@ def test_query_with_union_but_union_softdelete_disabled(snapshot, seeded_session
 
     assert sorted(test_query.all(), key=lambda x: x.id) == sorted(all_children, key=lambda x: x.id)
 
-    snapshot.assert_match(test_query.all())
+    snapshot.assert_match(sorted(test_query.all(), key=lambda i: i.id))
 
 
 def test_ensure_aggregate_from_multiple_table_deletion_works_active_object_count(snapshot, seeded_session, rewriter):
@@ -70,14 +71,14 @@ def test_ensure_table_with_inheritance_works(snapshot, seeded_session, rewriter)
 
     test_query_results = test_query.all()
     assert len(test_query_results) == 2
-    snapshot.assert_match(test_query_results)
+    snapshot.assert_match(sorted(test_query_results, key=lambda i: i.id))
 
     all_active_and_deleted_derived_requests = (
         seeded_session.query(SDDerivedRequest).execution_options(include_deleted=True).all()
     )
 
     assert len(all_active_and_deleted_derived_requests) == 3
-    snapshot.assert_match(all_active_and_deleted_derived_requests)
+    snapshot.assert_match(sorted(all_active_and_deleted_derived_requests, key=lambda i: i.id))
 
 
 def test_ensure_table_with_inheritance_works_query_base(snapshot, seeded_session, rewriter):
@@ -94,7 +95,7 @@ def test_ensure_table_with_inheritance_works_query_base(snapshot, seeded_session
     try:
         # Accessing a field in a SDDerived Request will trigger an additional query with
         # a `FromStatement` as the statement, instead of a normal Select
-        request.int_field
+        request.derived_field
     except Exception as exc:
         assert False, f"'Exception was raised {exc}"
 
@@ -113,3 +114,21 @@ def test_query_with_table_clause_as_table(snapshot, seeded_session, rewriter):
     # Table as a TableClause
     test_query_table_clause: Select = select(text('id')).select_from(table("sdderivedrequest"))
     snapshot.assert_match(str(rewriter.rewrite_select(test_query_table_clause)))
+
+
+def test_insert_with_returning(snapshot, seeded_session, rewriter, db_connection):
+    """Insert with RETURNING is considered a *Select* by SQLAlchemy, since it returns data :dizzy:
+    that means we need to actively protect against this case"""
+
+    # RETURNING is not supported in SQLite
+    if db_connection.dialect.name == 'sqlite':
+        pytest.skip('SQLite does not support "INSERT...RETURNING"')
+
+    insert_stmt = insert(SDSimpleTable).values(int_field=10).returning(SDSimpleTable)
+
+    # Generate an Insert + RETURNING
+    insert_returning = select(SDSimpleTable).from_statement(insert_stmt)
+
+    result = seeded_session.execute(insert_returning)
+
+    assert list(result)[0][0].int_field == 10


### PR DESCRIPTION
A `select(X).from_statement(insert(...).returning(...))` is confusingly marked as a `is_select=True` in SQLAlchemy's ORMExecuteState. This PR integrates additional security measures in the Query Rewriter to ensure that we are only operating on `Select`-like statements.